### PR TITLE
Installer-Action von FOR nutzen

### DIFF
--- a/.github/workflows/publish-to-redaxo-org.yml
+++ b/.github/workflows/publish-to-redaxo-org.yml
@@ -1,0 +1,19 @@
+# Instructions: https://github.com/FriendsOfREDAXO/installer-action/
+
+name: Publish to REDAXO.org
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  redaxo_publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: FriendsOfREDAXO/installer-action@v1
+      with:
+        myredaxo-username: ${{ secrets.MYREDAXO_USERNAME }}
+        myredaxo-api-key: ${{ secrets.MYREDAXO_API_KEY }}
+        description: ${{ github.event.release.body }}
+        version: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
Hi Andi,

tolle Sache - die Idee für dieses Addon hatte ich auch schon lange und jetzt muss ich sie nicht mehr selbst umsetzen. Danke dafür!

Mit diesem PR kannst du die Installer Action von FriendsOfREDAXO auch in deinem Repository nutzen. Dieser PR setzt Schritt 2 der Anleitung um, du müsstest in deinem GitHub- und MyREDAXO-Profil noch die Schritte 1 und 3 umsetzen: https://github.com/FriendsOfREDAXO/installer-action#usage

VG